### PR TITLE
menu: add possibility to define icons for menu items

### DIFF
--- a/invenio_administration/config.py
+++ b/invenio_administration/config.py
@@ -15,17 +15,6 @@ By default (``None``) uses the Flask-Admin template."""
 ADMINISTRATION_APPNAME = "Invenio-Administration"
 """Name of the Flask-Admin app (also the page title of admin panel)."""
 
-# ADMINISTRATION_LOGIN_ENDPOINT = "security.login"
-"""Endpoint name of the login view. Anonymous users trying to access admin
-panel will be redirected to this endpoint."""
-
-# ADMINISTRATION_LOGOUT_ENDPOINT = "security.logout"
-"""Endpoint name of logout view."""
-
-# ADMINISTRATION_PERMISSION_FACTORY =
-# "invenio_administration.permissions.admin_permission_factory"
-"""Permission factory for the admin views."""
-
 ADMINISTRATION_DASHBOARD_VIEW = (
     "invenio_administration.views.dashboard.AdminDashboardView"
 )

--- a/invenio_administration/menu/menu.py
+++ b/invenio_administration/menu/menu.py
@@ -9,6 +9,7 @@
 """Invenio Administration menu module."""
 
 from flask import request
+from invenio_theme.proxies import current_theme_icons
 
 
 class AdminMenu:
@@ -34,6 +35,7 @@ class AdminMenu:
             order = menu_entry.order
             active_when = menu_entry.active_when
             label = menu_entry.label
+            icon = menu_entry.icon
 
             if category:
                 category_menu = main_menu.submenu(category)
@@ -43,6 +45,7 @@ class AdminMenu:
                     text=label,
                     order=order,
                     active_when=active_when or self.default_active_when,
+                    icon=icon,
                 )
             else:
                 main_menu.submenu(name).register(
@@ -50,6 +53,7 @@ class AdminMenu:
                     text=label,
                     order=order,
                     active_when=active_when or self.default_active_when,
+                    icon=icon,
                 )
 
     def add_menu_item(self, item, index=None):
@@ -70,6 +74,8 @@ class AdminMenu:
             name=view.name,
             category=view.category,
             label=view.menu_label,
+            order=view.order,
+            icon_key=view.icon,
         )
         self.add_menu_item(menu_item, index)
 
@@ -83,7 +89,14 @@ class MenuItem:
     """Class for menu item."""
 
     def __init__(
-        self, name="", endpoint="", category="", order=0, active_when=None, label=""
+        self,
+        name="",
+        endpoint="",
+        category="",
+        order=0,
+        icon_key=None,
+        active_when=None,
+        label="",
     ):
         """Constructor."""
         self.name = name
@@ -91,4 +104,13 @@ class MenuItem:
         self.category = category
         self.order = order
         self.active_when = active_when
+        self.icon_key = icon_key
         self.label = label
+
+    @property
+    def icon(self):
+        """Return corresponding template path for icon."""
+        if not self.icon_key:
+            return None
+
+        return current_theme_icons[self.icon_key]

--- a/invenio_administration/templates/semantic-ui/invenio_administration/sidebar/sidenav.html
+++ b/invenio_administration/templates/semantic-ui/invenio_administration/sidebar/sidenav.html
@@ -20,6 +20,9 @@
         {{ item.text }}
       </a>
 
+      {% if item.icon %}
+        <i class="{{ item.icon }}"></i>
+      {% endif %}
     {% endif %}
 
   {% endfor %}

--- a/invenio_administration/views/base.py
+++ b/invenio_administration/views/base.py
@@ -33,6 +33,8 @@ class AdminView(MethodView):
     template = "invenio_administration/index.html"
     url = None
     menu_label = None
+    order = None
+    icon = None
 
     decorators = [roles_required("admin")]
 
@@ -43,6 +45,8 @@ class AdminView(MethodView):
         url=None,
         extension_name=None,
         admin=None,
+        order=0,
+        icon=None
     ):
         """Constructor."""
         if self.extension_name is None:
@@ -58,6 +62,12 @@ class AdminView(MethodView):
             self.menu_label = self.name
 
         self.administration = admin
+
+        if self.order is None:
+            self.order = order
+
+        if self.icon is None:
+            self.icon = icon
 
         self.url = url or self._get_view_url(self.url)
 
@@ -130,9 +140,11 @@ class AdminResourceBaseView(AdminView):
         url=None,
         extension_name=None,
         admin=None,
+        order=0,
+        icon=None
     ):
         """Constructor."""
-        super().__init__(name, category, url, extension_name, admin)
+        super().__init__(name, category, url, extension_name, admin, order, icon)
 
         if self.extension_name is None:
             raise MissingExtensionName(self.__class__.__name__)

--- a/invenio_administration/views/dashboard.py
+++ b/invenio_administration/views/dashboard.py
@@ -17,3 +17,4 @@ class AdminDashboardView(AdminView):
     template = "invenio_administration/index.html"
     name = "dashboard"
     url = "/"
+    icon = "home"

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,9 +32,10 @@ install_requires =
     invenio-accounts>=1.2.1
     invenio-base>=1.2.9
     invenio-db>=1.0.9
-    invenio-vocabularies>=0.12.0,<0.13.0
+    invenio-vocabularies>=0.12.0
     invenio-records-resources>=0.19.6
-    invenio-search-ui>=2.1.2,<2.2.0
+    invenio-search-ui>=2.1.2
+    invenio-theme>=1.1.0
 
 [options.extras_require]
 tests =


### PR DESCRIPTION
added a configuration variable that can hold templates that can then be declared for views, the menu item of that view will be displayed with that icon.

closes https://github.com/inveniosoftware/invenio-administration/issues/22

![Screenshot from 2022-08-17 15-24-01](https://user-images.githubusercontent.com/55200060/185148169-6fc5fbe3-92d4-45a6-aed8-9333a8ba9d1f.png)
