### PR TITLE
global: bumped invenio-vocabularies

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -10,14 +10,4 @@ extends:
   - '@inveniosoftware/eslint-config-invenio'
   - '@inveniosoftware/eslint-config-invenio/prettier'
 
-parser: babel-eslint
-
-parserOptions:
-  sourceType: module
-  allowImportExportEverywhere: true
-
-env:
-  browser: true
-  es6: true
-  jest: true
-  node: true
+parser: '@babel/eslint-parser'

--- a/invenio_administration/assets/semantic-ui/js/invenio_administration/theme.js
+++ b/invenio_administration/assets/semantic-ui/js/invenio_administration/theme.js
@@ -1,6 +1,6 @@
 import $ from "jquery";
 
-const menuId = "#invenio-admin-top-nav"
+const menuId = "#invenio-admin-top-nav";
 
 /* Expand and collapse navbar  */
 const toggleIcon = $("#rdm-burger-menu-icon");

--- a/run-js-linter.sh
+++ b/run-js-linter.sh
@@ -18,7 +18,7 @@ NC='\033[0m' # No Color
 for arg in $@; do
 	case ${arg} in
 		-i|--install)
-			npm install @inveniosoftware/eslint-config-invenio@^1.0.0;;
+			npm install --no-save --no-package-lock @inveniosoftware/eslint-config-invenio@^1.0.0;;
 		*)
 			printf "Argument ${RED}$arg${NC} not supported\n"
 			exit;;
@@ -26,4 +26,4 @@ for arg in $@; do
 done
 
 printf "${GREEN}Run eslint${NC}\n"
-npx eslint -c .eslintrc.yml invenio_administration/**/*.js --fix
+npx eslint -c .eslintrc.yml invenio_administration/**/*.js

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
     invenio-accounts>=1.2.1
     invenio-base>=1.2.9
     invenio-db>=1.0.9
-    invenio-vocabularies>=0.11.5,<0.12.0
+    invenio-vocabularies>=0.12.0,<0.13.0
     invenio-records-resources>=0.19.6
     invenio-search-ui>=2.1.2,<2.2.0
 


### PR DESCRIPTION
closes https://github.com/inveniosoftware/invenio-administration/issues/25

Bumped `invenio-vocabularies` to ƒix conflicts with `invenio-rdm-records` [0.36.0 release](https://github.com/inveniosoftware/invenio-rdm-records/commit/f8fd99726e4dacb638b5dded764f32828c3e729e)

`invenio-vocabularies` 0.12.0 release can be found [here](https://github.com/inveniosoftware/invenio-vocabularies/commit/200a5690fbccb17f7399eeb6e883b8484b606383) and does not seem to have breaking changes for `invenio-administration`

- Bumped `invenio-vocabularies` version.
- Changed `eslint` parser to match `eslint-config-invenio` after this [change](https://github.com/inveniosoftware/eslint-config-invenio/commit/9a115a061dc6984f77237ba600dcc586664d6d93). Tests for `eslint`were failing otherwise, as the `babel-eslint` parser was not found.