### PR TITLE
details back-button: add more spacing to headline

### DIFF
--- a/invenio_administration/templates/semantic-ui/invenio_administration/macros.html
+++ b/invenio_administration/templates/semantic-ui/invenio_administration/macros.html
@@ -8,7 +8,7 @@
 
 {% macro go_back() %}
   {% if request.referrer %}
-    <div class="mb-10">
+    <div class="rel-mb-2">
       <a href="{{ request.referrer }}" class="ui mini button labeled icon rel-mr-1">
           <i class="ui icon left arrow" aria-hidden="true"></i>
           {{ _('Back')}}


### PR DESCRIPTION
Adds a bit more spacing between the back-button and the headline.

## Before
![Screenshot 2022-09-26 at 14 47 45](https://user-images.githubusercontent.com/21052053/192281057-61274156-303d-40e6-91e3-74c56dfce5db.png)


## After
![Screenshot 2022-09-26 at 14 48 48](https://user-images.githubusercontent.com/21052053/192281071-158f0e46-9dcb-4265-9732-e44ed82196ff.png)

