### PR TITLE
migrate: flask_babelex replaced by invenio_i18n

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,12 @@
 Changes
 =======
 
+Version 1.1.0 (released 2023-03-02)
+
+- remove deprecated flask-babelex dependency and imports
+- upgrade invenio-theme, invenio-vocabularies
+- fix form field sorting order
+
 Version 1.0.6 (released 2023-02-15)
 
 - forms: add support for checkbox, dropdown and textarea fields

--- a/invenio_administration/__init__.py
+++ b/invenio_administration/__init__.py
@@ -10,6 +10,6 @@
 
 from .ext import InvenioAdministration
 
-__version__ = "1.0.6"
+__version__ = "1.1.0"
 
 __all__ = ["InvenioAdministration"]

--- a/invenio_administration/errors.py
+++ b/invenio_administration/errors.py
@@ -2,13 +2,14 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2022 CERN.
+# Copyright (C) 2023 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """Invenio Administration exceptions."""
 
-from flask_babelex import gettext as _
+from invenio_i18n import gettext as _
 
 
 class InvalidResource(Exception):

--- a/invenio_administration/menu/menu.py
+++ b/invenio_administration/menu/menu.py
@@ -2,6 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2022 CERN.
+# Copyright (C) 2023 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -11,7 +12,7 @@
 import urllib.parse
 
 from flask import request
-from flask_babelex import lazy_gettext as _
+from invenio_i18n import lazy_gettext as _
 from invenio_theme.proxies import current_theme_icons
 from speaklater import make_lazy_string
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,10 +32,10 @@ install_requires =
     invenio-accounts>=2.0.0,<3.0.0
     invenio-base>=1.2.9,<2.0.0
     invenio-db[postgresql,mysql]>=1.0.9,<2.0.0
-    invenio-vocabularies>=1.0.0,<2.0.0
+    invenio-vocabularies>=1.1.0,<2.0.0
     invenio-records-resources>=1.0.0,<2.0.0
     invenio-search-ui>=2.1.2,<3.0.0
-    invenio-theme>=1.1.0,<2.0.0
+    invenio-theme>=2.0.0,<3.0.0
 
 [options.extras_require]
 tests =


### PR DESCRIPTION
- NOTE: invenio-i18n has to be released first