### PR TITLE
global: fix fields sorting in details, create and edit views

### DIFF
--- a/invenio_administration/assets/semantic-ui/js/invenio_administration/src/components/utils.js
+++ b/invenio_administration/assets/semantic-ui/js/invenio_administration/src/components/utils.js
@@ -9,8 +9,8 @@ export const sortFields = (schema) => {
     Object.entries(schema)
       // sort by order
       .sort((a, b) => {
-        if (a[1]?.ui && b[1].ui) {
-          return a[1].ui.order > b[1].ui.order;
+        if (a[1] && b[1]) {
+          return a[1].order - b[1].order;
         }
         return true;
       })

--- a/invenio_administration/assets/semantic-ui/js/invenio_administration/src/details/AdminDetailsView.js
+++ b/invenio_administration/assets/semantic-ui/js/invenio_administration/src/details/AdminDetailsView.js
@@ -75,7 +75,7 @@ export default class AdminDetailsView extends Component {
       uiSchema,
     } = this.props;
     const { loading, data, error } = this.state;
-    const sortedColumns = sortFields(resourceSchema);
+    const sortedColumns = sortFields(uiSchema);
     return (
       <Loader isLoading={loading}>
         <ErrorPage
@@ -107,7 +107,11 @@ export default class AdminDetailsView extends Component {
           </Grid>
           <Divider />
           <Container fluid>
-            <DetailsTable data={data} schema={sortedColumns} uiSchema={uiSchema} />
+            <DetailsTable
+              data={data}
+              schema={resourceSchema}
+              uiSchema={sortedColumns}
+            />
             {this.childrenWithData(data, columns)}
           </Container>
         </ErrorPage>

--- a/invenio_administration/assets/semantic-ui/js/invenio_administration/src/formik/GenerateForm.js
+++ b/invenio_administration/assets/semantic-ui/js/invenio_administration/src/formik/GenerateForm.js
@@ -7,6 +7,7 @@ import {
   TextArea,
 } from "react-invenio-forms";
 import _capitalize from "lodash/capitalize";
+import _get from "lodash/get";
 import PropTypes from "prop-types";
 import { Form, Segment, Header } from "semantic-ui-react";
 import { AdminArrayField } from "./array";
@@ -69,9 +70,10 @@ const mapFormFields = (obj, parentField, isCreate, formFieldsConfig, dropDumpOnl
     return null;
   }
 
-  const sortedFields = sortFields(obj);
+  const sortedFields = sortFields(formFieldsConfig);
+  const elements = Object.entries(sortedFields).map(([fieldName]) => {
+    const fieldSchema = _get(obj, fieldName);
 
-  const elements = Object.entries(sortedFields).map(([fieldName, fieldSchema]) => {
     if (fieldSchema.readOnly && dropDumpOnly) {
       return null;
     }


### PR DESCRIPTION
* closes https://github.com/inveniosoftware/invenio-administration/issues/155
* requires https://github.com/inveniosoftware/invenio-rdm-records/pull/1193

Before: fields order in details, create and edit views is alphabetical
After: fields order corresponds to the one specified in [config](https://github.com/inveniosoftware/invenio-banners/blob/master/invenio_banners/administration/banners.py).

Details page:
![Screenshot 2023-02-16 at 14 26 51](https://user-images.githubusercontent.com/61321254/219381830-17f18f1b-27fc-433a-b5a7-92b6f911682c.png)

Create page:
![Screenshot 2023-02-16 at 14 42 06](https://user-images.githubusercontent.com/61321254/219381868-a82fdc05-c6da-401a-9b89-9723a9198077.png)

Edit page:
![Screenshot 2023-02-16 at 14 42 42](https://user-images.githubusercontent.com/61321254/219381932-789166aa-6ab6-47bb-b5d3-bc2056c63577.png)
