### PR TITLE
Removed dependency on OAI-PMH, the menu should be inside the OAIPMH panel

### DIFF
--- a/invenio_administration/templates/semantic-ui/invenio_administration/header/header_login.html
+++ b/invenio_administration/templates/semantic-ui/invenio_administration/header/header_login.html
@@ -24,24 +24,6 @@
         </form>
     {%- else %}
 
-        <div role="menuitem" aria-labelledby="create-menu" class="ui dropdown floating rel-p-1 pr-15 computer only">
-            <i class="fitted plus icon inverted" aria-hidden="true"></i>
-            <i class="fitted dropdown icon inverted" aria-hidden="true"></i>
-            <div id="create-menu" class="menu">
-              <a class="item"
-                  href="{{ url_for('administration.oaipmh_create') }}">{{ _('New OAI-PMH set') }}
-              </a>
-            </div>
-        </div>
-
-        <div class="sub-menu mobile tablet only">
-          <h2 class="ui small header">{{ _('Actions') }}</h2>
-            <a role="menuitem" class="item" href="{{ url_for('administration.oaipmh_create') }}">
-              <i class="plus icon" aria-hidden="true"></i>
-              {{ _('New OAI-PMH set') }}
-            </a>
-        </div>
-
         {%- if config.USERPROFILES %}
           <div role="menuitem" id="user-profile-dropdown" class="ui floating dropdown computer only">
             <button id="user-profile-dropdown-btn"

--- a/invenio_administration/translations/messages.pot
+++ b/invenio_administration/translations/messages.pot
@@ -105,11 +105,6 @@ msgstr ""
 msgid "Sign up"
 msgstr ""
 
-#: invenio_administration/templates/semantic-ui/invenio_administration/header/header_login.html:32
-#: invenio_administration/templates/semantic-ui/invenio_administration/header/header_login.html:41
-msgid "New OAI-PMH set"
-msgstr ""
-
 #: invenio_administration/templates/semantic-ui/invenio_administration/header/header_login.html:38
 msgid "Actions"
 msgstr ""


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

This pull request fixes issue #200 - invenio-administration uses `url_for` for OAI-PMH server but does not depend on it. The proposed solution is just to remove the explicit menu link for the new oaipmh set. A new set can be created from within the oai listing panel the same way other objects are created: https://github.com/inveniosoftware/invenio-rdm-records/blob/master/invenio_rdm_records/administration/views/oai.py


### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
