### PR TITLE
forms: generate & use yup validation schemas

### DIFF
--- a/invenio_administration/assets/semantic-ui/js/invenio_administration/src/formik/ActionForm.js
+++ b/invenio_administration/assets/semantic-ui/js/invenio_administration/src/formik/ActionForm.js
@@ -10,6 +10,7 @@ import isEmpty from "lodash/isEmpty";
 import { GenerateForm } from "./GenerateForm";
 import { deserializeFieldErrors } from "../components/utils";
 import { i18next } from "@translations/invenio_administration/i18next";
+import { generateValidationSchema } from "./validation";
 
 export class ActionForm extends Component {
   constructor(props) {
@@ -79,7 +80,11 @@ export class ActionForm extends Component {
     const { actionSchema, formFields, actionCancelCallback } = this.props;
     const { loading, formData, error } = this.state;
     return (
-      <Formik initialValues={formData} onSubmit={this.onSubmit}>
+      <Formik
+        initialValues={formData}
+        validationSchema={generateValidationSchema(actionSchema)}
+        onSubmit={this.onSubmit}
+      >
         {(props) => (
           <>
             <Modal.Content>

--- a/invenio_administration/assets/semantic-ui/js/invenio_administration/src/formik/AdminForm.js
+++ b/invenio_administration/assets/semantic-ui/js/invenio_administration/src/formik/AdminForm.js
@@ -11,6 +11,7 @@ import { GenerateForm } from "./GenerateForm";
 import { deserializeFieldErrors } from "../components/utils";
 import { i18next } from "@translations/invenio_administration/i18next";
 import mapValues from "lodash/mapValues";
+import { generateValidationSchema } from "./validation";
 
 export class AdminForm extends Component {
   constructor(props) {
@@ -86,7 +87,11 @@ export class AdminForm extends Component {
     const { formData, error } = this.state;
 
     return (
-      <Formik initialValues={formData} onSubmit={this.onSubmit}>
+      <Formik
+        initialValues={formData}
+        validationSchema={generateValidationSchema(resourceSchema)}
+        onSubmit={this.onSubmit}
+      >
         {(props) => {
           return (
             <>

--- a/invenio_administration/assets/semantic-ui/js/invenio_administration/src/formik/validation.js
+++ b/invenio_administration/assets/semantic-ui/js/invenio_administration/src/formik/validation.js
@@ -1,0 +1,46 @@
+import * as Yup from "yup";
+import mapValues from "lodash/mapValues";
+
+const toYupSchema = (fieldSchema) => {
+  switch (fieldSchema.type) {
+    case "number":
+      return Yup.number();
+    case "string":
+      return Yup.string();
+    case "bool":
+      return Yup.bool();
+    case "array":
+      return Yup.array();
+    case "object":
+      return Yup.object({});
+    case "html":
+      return Yup.string();
+    default:
+      return Yup.mixed();
+  }
+};
+
+const mapValidationRules = (yupSchema, fieldSchema) => {
+  let validationSchema = yupSchema;
+
+  if (fieldSchema.required) {
+    validationSchema = validationSchema.required();
+  }
+
+  return validationSchema;
+};
+
+const generateValidationSchema = (resourceSchema) => {
+  if (Object.keys(resourceSchema).length === 0) {
+    return;
+  }
+
+  const yupFieldsSchema = mapValues(resourceSchema, (fieldSchema) => {
+    const yupSchema = toYupSchema(fieldSchema);
+    return mapValidationRules(yupSchema, fieldSchema);
+  });
+
+  return Yup.object({ ...yupFieldsSchema });
+};
+
+export { generateValidationSchema };


### PR DESCRIPTION
### Description

* Fixes https://github.com/inveniosoftware/invenio-banners/issues/26 by fixing form validation of required dropdown fields.

* Some required SUI inputs cannot be validated natively by browser (e.g. Dropdown). It is possible to submit a form with a dropdown input marked as required, having undefined value.

* This PR introduces an autogenerated Yup form validation schemas to address the issue.
* Validation schema is generated based on resource's marshmallow schema.
* Currently it supports only field type (numeric, string,...) and `required` validation rules, more rules could be implemented in [`mapValidationRules`](https://github.com/inveniosoftware/invenio-administration/pull/206/files#diff-da20a075b71c96578399e37e1cd76275ebd661442ce540ac539f854a44be700cR23) function.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
