### PR TITLE
bug: fix type for BoolFormatter value

### DIFF
--- a/invenio_administration/assets/semantic-ui/js/invenio_administration/src/components/BoolFormatter.js
+++ b/invenio_administration/assets/semantic-ui/js/invenio_administration/src/components/BoolFormatter.js
@@ -25,7 +25,7 @@ BoolFormatter.propTypes = {
   value: PropTypes.bool.isRequired,
   icon: PropTypes.string,
   color: PropTypes.string,
-  tooltip: PropTypes.string,
+  tooltip: PropTypes.string.isRequired,
 };
 
 BoolFormatter.defaultProps = {

--- a/invenio_administration/assets/semantic-ui/js/invenio_administration/src/components/BoolFormatter.js
+++ b/invenio_administration/assets/semantic-ui/js/invenio_administration/src/components/BoolFormatter.js
@@ -22,7 +22,7 @@ class BoolFormatter extends React.Component {
 }
 
 BoolFormatter.propTypes = {
-  value: PropTypes.string.isRequired,
+  value: PropTypes.bool.isRequired,
   icon: PropTypes.string,
   color: PropTypes.string,
   tooltip: PropTypes.string,


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

> Please describe briefly your pull request.

#### 1st commit

`value` is used as a boolean, and therefore all the uses of this in the codebase pass a boolean test as value. I think value isn't a great name for this, but at least we should fix the expected type

```js
class BoolFormatter extends React.Component {
  render() {
    const { value, icon, color, tooltip } = this.props;
    if (!value) {
      return null;
    }
    return <Icon title={tooltip} name={icon} color={color} />;
  }
}
```

#### 2nd commit

There is a warning from eslint that we should provide a default value for the `tooltip` and looking at the repository, this icon is used to mean a variety of things such as activated, success, verified, confirmed, etc. As such I don't think we can define a sensible default value for `tooltip`

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
