### PR TITLE
js: remove required restriction on fieldSchema

### DIFF
--- a/invenio_administration/assets/semantic-ui/js/invenio_administration/src/components/Formatter.js
+++ b/invenio_administration/assets/semantic-ui/js/invenio_administration/src/components/Formatter.js
@@ -44,7 +44,11 @@ Formatter.propTypes = {
   resourceSchema: PropTypes.object.isRequired,
   result: PropTypes.object.isRequired,
   property: PropTypes.string.isRequired,
-  fieldSchema: PropTypes.object.isRequired,
+  fieldSchema: PropTypes.object,
+};
+
+Formatter.defaultProps = {
+  fieldSchema: {},
 };
 
 export default Formatter;


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

> Please describe briefly your pull request.

The only time `fieldSchema` is only used as follows:
```js
if (fieldSchema?.escape) {
      return <div dangerouslySetInnerHTML={{ __html: value }} />;
}
```

and when `fieldSchema` was committed:

https://github.com/inveniosoftware/invenio-administration/commit/e30d0f81886c5018ed613f6a1ec6a9cd019dadbf

the other reference to this function was not updated:

https://github.com/inveniosoftware/invenio-administration/blob/main/invenio_administration/assets/semantic-ui/js/invenio_administration/src/search/SearchResultItem.js#L68-L80

Therefore I think we can just say it's not required as the implementation accounts for it not having the key

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
