### PR TITLE
global: remove dependency on invenio-vocabularies

### DIFF
--- a/invenio_administration/marshmallow_utils.py
+++ b/invenio_administration/marshmallow_utils.py
@@ -8,20 +8,9 @@
 
 """Invenio administration marshmallow utils module."""
 
-from invenio_vocabularies.services.schema import (
-    BaseVocabularySchema,
-    ContribVocabularyRelationSchema,
-    VocabularyRelationSchema,
-)
 from marshmallow import fields
 from marshmallow_utils import fields as invenio_fields
 from marshmallow_utils.fields import EDTFDateString, EDTFDateTimeString
-
-vocabulary_schemas = [
-    ContribVocabularyRelationSchema,
-    BaseVocabularySchema,
-    VocabularyRelationSchema,
-]
 
 custom_mapping = {
     # marshmallow
@@ -118,11 +107,7 @@ def jsonify_schema(schema):
         }
 
         if nested_field:
-            if any([isinstance(field_type.schema, x) for x in vocabulary_schemas]):
-                schema_type = "vocabulary"
-            else:
-                schema_type = "object"
-
+            schema_type = getattr(field_type, "administration_schema_type", "object")
             schema_dict[field].update(
                 {
                     "type": schema_type,
@@ -131,11 +116,14 @@ def jsonify_schema(schema):
             )
         elif list_field and isinstance(field_type.inner, fields.Nested):
             # list of objects (vocabularies or nested)
+            schema_type = getattr(
+                field_type.inner.schema, "administration_schema_type", "object"
+            )
             schema_dict[field].update(
                 {
                     "type": "array",
                     "items": {
-                        "type": "object",
+                        "type": schema_type,
                         "properties": jsonify_schema(field_type.inner.schema),
                     },
                 }

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,6 @@ install_requires =
     invenio-accounts>=5.0.0,<6.0.0
     invenio-base>=1.3.0,<2.0.0
     invenio-db[postgresql,mysql]>=1.0.9,<2.0.0
-    invenio-vocabularies>=4.0.0,<5.0.0
     invenio-records-resources>=6.0.0,<7.0.0
     invenio-search-ui>=2.1.2,<3.0.0
     invenio-theme>=3.0.0,<4.0.0


### PR DESCRIPTION
* Removes the dependency from invenio-vocabularies.
* Delegates administration UI schema type definition to the mashmallow
  class.
* :warning: https://github.com/inveniosoftware/invenio-vocabularies/pull/358 should be merged first to make sure this works
