### PR TITLE
theme: move TinyMCE from invenio-app-rdm to invenio-administration

### DIFF
--- a/invenio_administration/webpack.py
+++ b/invenio_administration/webpack.py
@@ -27,6 +27,8 @@ theme = WebpackThemeBundle(
             },
             dependencies={
                 "@babel/runtime": "^7.9.0",
+                "@tinymce/tinymce-react": "^4.3.0",
+                "tinymce": "^6.7.2",
                 "i18next": "^20.3.0",
                 "i18next-browser-languagedetector": "^6.1.0",
                 "luxon": "^1.23.0",
@@ -47,6 +49,22 @@ theme = WebpackThemeBundle(
                 "@js/invenio_administration": "js/invenio_administration",
                 "@translations/invenio_administration": "translations/invenio_administration",
             },
+            copy=[
+                # Copy some assets into "static/dist", as TinyMCE requires that
+                # Note that the base path for all entries is the `config.json` directory
+                {
+                    "from": "../node_modules/tinymce/skins/content/default/content.css",
+                    "to": "../../static/dist/js/skins/content/default",
+                },
+                {
+                    "from": "../node_modules/tinymce/skins/ui/oxide/skin.min.css",
+                    "to": "../../static/dist/js/skins/ui/oxide",
+                },
+                {
+                    "from": "../node_modules/tinymce/skins/ui/oxide/content.min.css",
+                    "to": "../../static/dist/js/skins/ui/oxide",
+                },
+            ],
         ),
     },
 )


### PR DESCRIPTION
* invenio-administration depends on TinyMCE
* Added it as a webpack dependency

See: https://github.com/inveniosoftware/invenio-app-rdm/pull/3126


closes: https://github.com/CERNDocumentServer/cds-ils/issues/1006