### PR TITLE
index: change welcome message to be non RDM-specific

### DIFF
--- a/invenio_administration/templates/semantic-ui/invenio_administration/index.html
+++ b/invenio_administration/templates/semantic-ui/invenio_administration/index.html
@@ -14,7 +14,7 @@
   <div class="two column stackable ui grid rel-mt-5 computer tablet only">
     <div class="dashboard-header eight wide column">
       <div class="header">
-        <h1>{{ _('Welcome to InvenioRDM Administration')}}</h1>
+        <h1>{{ _('Welcome to {sitename} Administration').format(sitename=config.THEME_SITENAME )}}</h1>
       </div>
     </div>
     <div class="six wide column ">
@@ -26,7 +26,7 @@
   <div class="two column mobile only row">
     <div class="column">
       <div class="header text-align-center">
-        <h1>{{ _('Welcome to Invenio Administration')}}</h1>
+        <h1>{{ _('Welcome to {sitename} Administration').format(sitename=config.THEME_SITENAME )}}</h1>
         <p>{{ _('My managment tool')}}</p>
       </div>
     </div>


### PR DESCRIPTION
Invenio-ILS now also uses invenio-administration and requires the welcome message to not be RDM specific.
closes: https://github.com/CERNDocumentServer/cds-ils/issues/102