### PR TITLE
admin: render HTTP errors inside administration layout

### DIFF
--- a/invenio_administration/admin.py
+++ b/invenio_administration/admin.py
@@ -17,6 +17,7 @@ from werkzeug.utils import import_string
 
 from invenio_administration.menu import AdminMenu
 
+from .error_handlers import register_blueprint_error_handlers
 from .views.base import AdminFormView, AdminResourceDetailView, AdminView
 
 
@@ -89,6 +90,7 @@ class Administration:
             template_folder="templates",
             static_folder="static",
         )
+        register_blueprint_error_handlers(self.blueprint)
 
     @property
     def views(self):

--- a/invenio_administration/error_handlers.py
+++ b/invenio_administration/error_handlers.py
@@ -1,0 +1,131 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2026 CERN.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Administration HTTP error page handlers."""
+
+from flask import current_app, render_template, request, url_for
+from invenio_i18n import lazy_gettext as _
+from invenio_theme import views as theme_views
+from werkzeug.exceptions import HTTPException
+
+_ERROR_CONTENT = {
+    401: {
+        "title": _("Sign in required"),
+        "message": _(
+            "You need to sign in before you can continue in the administration panel."
+        ),
+    },
+    403: {
+        "title": _("Access denied"),
+        "message": _("You do not have permission to access this administration page."),
+    },
+    404: {
+        "title": _("Page not found"),
+        "message": _("The administration page you requested could not be found."),
+    },
+    429: {
+        "title": _("Too many requests"),
+        "message": _(
+            "Too many requests were sent from your session. Please try again in a moment."
+        ),
+    },
+    500: {
+        "title": _("Something went wrong"),
+        "message": _(
+            "An unexpected error occurred while loading the administration panel."
+        ),
+    },
+}
+
+_ADMIN_ERROR_CODES = (401, 403, 404, 429, 500)
+
+
+def _is_administration_request():
+    """Check if the current request targets the administration UI."""
+    admin_ext = current_app.extensions.get("invenio-administration")
+    if not admin_ext:
+        return False
+
+    admin_url = admin_ext.administration.url.rstrip("/")
+    request_path = request.path.rstrip("/")
+
+    if request_path == admin_url:
+        return True
+
+    return bool(admin_url and request_path.startswith(f"{admin_url}/"))
+
+
+def _render_administration_error(error):
+    """Render the administration error page."""
+    status_code = error.code if isinstance(error, HTTPException) else 500
+    content = _ERROR_CONTENT.get(status_code, _ERROR_CONTENT[500])
+
+    if status_code >= 500:
+        current_app.logger.exception("Administration panel error")
+
+    admin_ext = current_app.extensions["invenio-administration"]
+    dashboard_endpoint = f"{admin_ext.administration.endpoint}.dashboard"
+
+    return (
+        render_template(
+            "invenio_administration/error.html",
+            title=content["title"],
+            error_code=status_code,
+            error_message=content["message"],
+            back_url=url_for(dashboard_endpoint),
+        ),
+        status_code,
+    )
+
+
+def _administration_error_or_theme(error, theme_handler):
+    """Render admin errors in the admin shell; keep theme handlers elsewhere."""
+    if _is_administration_request():
+        return _render_administration_error(error)
+
+    return theme_handler(error)
+
+
+def register_blueprint_error_handlers(blueprint):
+    """Register error handlers on the administration blueprint."""
+    # Flask resolves code-specific handlers before generic exception handlers.
+    # invenio-theme registers app-level 403/404/etc., so blueprint handlers must
+    # be registered per status code to take precedence inside admin views.
+    for code in _ADMIN_ERROR_CODES:
+        blueprint.register_error_handler(code, _render_administration_error)
+
+    blueprint.register_error_handler(HTTPException, _render_administration_error)
+    blueprint.register_error_handler(Exception, _render_administration_error)
+
+
+def register_administration_error_handlers(app):
+    """Register app-level handlers for admin URLs without a matching view."""
+    app.register_error_handler(
+        401,
+        lambda error: _administration_error_or_theme(error, theme_views.unauthorized),
+    )
+    app.register_error_handler(
+        403,
+        lambda error: _administration_error_or_theme(
+            error, theme_views.insufficient_permissions
+        ),
+    )
+    app.register_error_handler(
+        404,
+        lambda error: _administration_error_or_theme(error, theme_views.page_not_found),
+    )
+    app.register_error_handler(
+        429,
+        lambda error: _administration_error_or_theme(
+            error, theme_views.too_many_requests
+        ),
+    )
+    app.register_error_handler(
+        500,
+        lambda error: _administration_error_or_theme(error, theme_views.internal_error),
+    )

--- a/invenio_administration/ext.py
+++ b/invenio_administration/ext.py
@@ -13,6 +13,7 @@ from invenio_base.utils import entry_points
 
 from . import config
 from .admin import Administration
+from .error_handlers import register_administration_error_handlers
 from .views.base import AdminResourceBaseView, AdminView
 
 
@@ -116,3 +117,4 @@ def finalize_app(app):
             view_class.set_schema(extension_name=extension_name)
 
     app.extensions["invenio-administration"].administration.init_menu()
+    register_administration_error_handlers(app)

--- a/invenio_administration/templates/semantic-ui/invenio_administration/error.html
+++ b/invenio_administration/templates/semantic-ui/invenio_administration/error.html
@@ -1,0 +1,23 @@
+{#
+  Copyright (C) 2026 CERN.
+
+  Invenio App RDM is free software; you can redistribute it and/or modify it
+  under the terms of the MIT License; see LICENSE file for more details.
+#}
+
+{% extends config.ADMINISTRATION_BASE_TEMPLATE %}
+
+{% block page_title %}
+  <h1 class="ui header">
+    <i class="bolt icon" aria-hidden="true"></i>
+    {{ title }}
+  </h1>
+  <div class="ui divider" aria-hidden="true"></div>
+{% endblock page_title %}
+
+{% block admin_page_content %}
+  <p>{{ error_message }}</p>
+  <a class="ui button primary rel-mt-2" href="{{ back_url }}">
+    {{ _("Back to administration page") }}
+  </a>
+{% endblock admin_page_content %}


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

Closes https://github.com/CERNDocumentServer/cds-rdm/issues/788
When a user hits an error inside the administration panel (403, 404, 500, etc.), Invenio currently falls back to the generic invenio-theme error pages, which drop the admin layout and show messages like “Permission required” with no way back to the dashboard. This PR registers administration-specific error handlers on the admin blueprint (per status code, so they take precedence over theme handlers) and app-level wrappers for unmatched /administration/... URLs, rendering a new error.html template inside the existing admin shell with a clear message and a “Back to administration page” link. Public site errors are unchanged — non-admin URLs still use the standard theme error pages.


<img width="1595" height="1050" alt="image" src="https://github.com/user-attachments/assets/1f9781e3-49f2-488f-a2ae-65d9f4baaba5" />


<img width="1595" height="1050" alt="image" src="https://github.com/user-attachments/assets/ac6e0a6b-4fe8-4b5f-8314-9e48069c522e" />






### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
